### PR TITLE
fix: case in importing header

### DIFF
--- a/src/keyboard/keyboard.cpp
+++ b/src/keyboard/keyboard.cpp
@@ -19,7 +19,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include "Keyboard.h"
+#include "keyboard.h"
 #include "KeyboardLayout.h"
 #include "Keyboard_de_DE.h"
 


### PR DESCRIPTION
no expertise in Arduino, but this makes compiling fail in Linux, at least for me